### PR TITLE
エンジンにconfigの設定値を共有するために追加

### DIFF
--- a/lib/vision.rb
+++ b/lib/vision.rb
@@ -4,4 +4,20 @@ require 'vision/engine'
 
 module Vision
   # Your code goes here...
+  class Configuration
+    attr_accessor :researcher_not_found_redirect_path
+
+    def initialize
+      @researcher_not_found_redirect_path = '/'
+    end
+  end
+
+  class << self
+    attr_accessor :config
+
+    def configure
+      self.config ||= Configuration.new
+      yield(config) if block_given?
+    end
+  end
 end

--- a/spec/dummy/config/initializers/vision.rb
+++ b/spec/dummy/config/initializers/vision.rb
@@ -1,3 +1,3 @@
-Vision.setup do |config|
-  config.your_config_var = "nyan cat"
+Vision.configure do |config|
+  config.researcher_not_found_redirect_path = '/'
 end

--- a/spec/dummy/config/initializers/vision.rb
+++ b/spec/dummy/config/initializers/vision.rb
@@ -1,0 +1,3 @@
+Vision.setup do |config|
+  config.your_config_var = "nyan cat"
+end


### PR DESCRIPTION
プロジェクトから、エンジンにconfigの設定値を共有するために追加します

initilizerに、vision.rbなどを置き、エンジン側に設定を渡す想定です。

```
Vision.configure do |config|
  config.researcher_not_found_redirect_path = '/'
end

```