### PR TITLE
Rails6.1、7.0、7.1でのテストを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,14 @@ jobs:
   code_analysis:
     name: code_analysis
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0']
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: ${{ matrix.ruby }}
       - name: cache vendor/bundle
         uses: actions/cache@v1
         with:
@@ -16,6 +19,10 @@ jobs:
           key: bundle-${{ hashFiles('**/Gemfile.lock') }}
       - name: bundle install
         run: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - name: Display ruby version
+        run: ruby -v
+      - name: Display rails version
+        run: bundle exec rails -v
       - name: Run rubocop
         run: bundle exec rubocop
       - name: Run haml-lint
@@ -27,11 +34,17 @@ jobs:
   rspec:
     name: rspec
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0']
+        rails: ['6_0', '6_1', '7_0', '7_1']
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: ${{ matrix.ruby }}
       - name: cache vendor/bundle
         uses: actions/cache@v1
         with:
@@ -39,5 +52,9 @@ jobs:
           key: bundle-${{ hashFiles('**/Gemfile.lock') }}
       - name: bundle install
         run: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
-      - name: Run rubocop
+      - name: Display ruby version
+        run: ruby -v
+      - name: Display rails version
+        run: bundle exec rails -v
+      - name: Run rspec
         run: bundle exec rspec

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+dependencies.delete_if { |d| d.name == 'rails' }
+gem 'rails', '~> 6.0.0'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+dependencies.delete_if { |d| d.name == 'rails' }
+gem 'rails', '~> 6.1.0'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+dependencies.delete_if { |d| d.name == 'rails' }
+gem 'rails', '~> 7.0.0'

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+dependencies.delete_if { |d| d.name == 'rails' }
+gem 'rails', '~> 7.1.0'

--- a/vision.gemspec
+++ b/vision.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0.6", ">= 6.0.6.1"
+  spec.add_dependency "rails", '>= 6.0.0', '< 7.2'
   spec.add_dependency "haml-rails", "~> 2.0"
 
   spec.test_files = Dir["spec/**/*"]


### PR DESCRIPTION
現在、visionではRailsのバージョンが6.0にしていますが、これを6.0、6.1、7.0、7.1を許容するように変更します。

それからbranch protectionを外しました。
マージしたらまた設定します。

## ruby/railsのバージョン確認

![image](https://github.com/academist/vision/assets/2942348/dad2e2e7-6023-4f7e-977b-171c22cec4b8)
