### PR TITLE
researchers#showでUserをparams[:handle]で探すように変更

### DIFF
--- a/app/controllers/vision/researchers_controller.rb
+++ b/app/controllers/vision/researchers_controller.rb
@@ -5,7 +5,10 @@ module Vision
     def index; end
 
     def show
-      @user = User.joins(:vision_profile).merge(Vision::Profile.where(published: true)).find(params[:id])
+      @user = User
+              .joins(:vision_profile)
+              .merge(Vision::Profile.where(published: true))
+              .find_by!(handle: params[:handle])
     end
   end
 end

--- a/app/controllers/vision/researchers_controller.rb
+++ b/app/controllers/vision/researchers_controller.rb
@@ -5,17 +5,7 @@ module Vision
     def index; end
 
     def show
-      raise ActionController::RoutingError, 'Not Found' unless profile&.published?
-    end
-
-    private
-
-    def profile
-      @profile ||= user.vision_profile
-    end
-
-    def user
-      @user ||= User.find(params[:id])
+      @user = User.joins(:vision_profile).merge(Vision::Profile.where(published: true)).find(params[:id])
     end
   end
 end

--- a/app/views/vision/researchers/show.html.haml
+++ b/app/views/vision/researchers/show.html.haml
@@ -1,1 +1,1 @@
-= render 'profile', profile: @profile
+= render 'profile', profile: @user.vision_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,3 @@
 Vision::Engine.routes.draw do
-  resources :researchers, only: :index do
-    member do
-      get :show
-    end
-  end
+  resources :researchers, only: %i[index show], param: :handle
 end

--- a/spec/dummy/app/views/vision/researchers/show.html.haml
+++ b/spec/dummy/app/views/vision/researchers/show.html.haml
@@ -1,6 +1,6 @@
 %section.bg-light.py-4
   .container
-    = render 'profile', profile: @profile
+    = render 'profile', profile: @user.vision_profile
 
     %section.bg-white.no-gutters
       .row

--- a/spec/dummy/db/migrate/20240724103703_add_handle_to_user.rb
+++ b/spec/dummy/db/migrate/20240724103703_add_handle_to_user.rb
@@ -1,0 +1,6 @@
+class AddHandleToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :handle, :string, after: :id
+    add_index :users, :handle, unique: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_30_135844) do
-
+ActiveRecord::Schema.define(version: 2024_07_24_103703) do
   create_table "sns_links", force: :cascade do |t|
     t.integer "link_type", null: false
     t.string "url", null: false
@@ -27,6 +26,7 @@ ActiveRecord::Schema.define(version: 2023_08_30_135844) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "handle"
   end
 
   create_table "vision_affiliations", force: :cascade do |t|

--- a/spec/dummy/spec/factories/user.rb
+++ b/spec/dummy/spec/factories/user.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :user do
+    handle { Faker::Internet.username(specifier: 3..20, separators: %w[- _]) }
     name { Faker::JapaneseMedia::DragonBall.character }
     email { Faker::Internet.email }
   end

--- a/spec/requests/vision/researchers_spec.rb
+++ b/spec/requests/vision/researchers_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe 'Vision::Researchers' do
       let(:vision_profile) { create(:vision_profile, user: user) }
 
       it 'raises ActionController::RoutingError' do
-        expect do
-          get_researcher_path
-        end.to raise_error(ActionController::RoutingError, 'Not Found')
+        expect { get_researcher_path }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/requests/vision/researchers_spec.rb
+++ b/spec/requests/vision/researchers_spec.rb
@@ -10,42 +10,40 @@ RSpec.describe 'Vision::Researchers' do
   end
 
   describe 'GET /vision/researchers/:id' do
-    subject(:get_researcher_path) { get researcher_path(user) }
+    subject(:action) { get researcher_path(user_id) }
 
-    let!(:user_with_vision_profile) { create(:user) }
-    let!(:user_without_vision_profile) { create(:user) }
-    let(:vision_profile) { create(:vision_profile, user: user) }
+    context 'user_idが存在しないとき' do
+      let(:user_id) { 0 }
 
-    context 'when vision profile is available' do
-      let(:user) { user_with_vision_profile }
+      it { expect { action }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'vision_profileが存在しないとき' do
+      let(:user) { create(:user) }
+      let(:user_id) { user.id }
+
+      it { expect { action }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'vision_profileが非公開のとき' do
+      let(:user) { create(:user) }
+      let(:user_id) { user.id }
+
+      before { create(:vision_profile, user: user, published: false) }
+
+      it { expect { action }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'vision_profileが公開のとき' do
+      let(:user) { create(:user) }
+      let(:user_id) { user.id }
 
       before do
-        vision_profile
-        get_researcher_path
+        create(:vision_profile, user: user, published: true)
+        action
       end
 
       it { expect(response).to have_http_status(:ok) }
-    end
-
-    # context 'when vision profile is available, published: false' do
-    #   let(:user) { user_with_vision_profile }
-    #   let(:vision_profile) { create(:vision_profile, :unpublished, user: user) }
-
-    #   before do
-    #     vision_profile
-    #     get_researcher_path
-    #   end
-
-    #   it { expect(response).to have_http_status(:redirect) }
-    # end
-
-    context 'when vision profile is not available' do
-      let(:user) { user_without_vision_profile }
-      let(:vision_profile) { create(:vision_profile, user: user) }
-
-      it 'raises ActionController::RoutingError' do
-        expect { get_researcher_path }.to raise_error(ActiveRecord::RecordNotFound)
-      end
     end
   end
 end

--- a/spec/requests/vision/researchers_spec.rb
+++ b/spec/requests/vision/researchers_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe 'Vision::Researchers' do
     it { expect(response).to have_http_status(:ok) }
   end
 
-  describe 'GET /vision/researchers/:id' do
-    subject(:action) { get researcher_path(user_id) }
+  describe 'GET /vision/researchers/:handle' do
+    subject(:action) { get researcher_path(handle) }
 
-    context 'user_idが存在しないとき' do
-      let(:user_id) { 0 }
+    context 'handleが存在しないとき' do
+      let(:handle) { 'nonexistence' }
 
       it { expect { action }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'vision_profileが存在しないとき' do
       let(:user) { create(:user) }
-      let(:user_id) { user.id }
+      let(:handle) { user.handle }
 
       it { expect { action }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'vision_profileが非公開のとき' do
       let(:user) { create(:user) }
-      let(:user_id) { user.id }
+      let(:handle) { user.handle }
 
       before { create(:vision_profile, user: user, published: false) }
 
@@ -36,7 +36,7 @@ RSpec.describe 'Vision::Researchers' do
 
     context 'vision_profileが公開のとき' do
       let(:user) { create(:user) }
-      let(:user_id) { user.id }
+      let(:handle) { user.handle }
 
       before do
         create(:vision_profile, user: user, published: true)


### PR DESCRIPTION
/vision/researchers/:idでしたが、番号よりハンドル名のほうがURLとして愛着が湧きそうなので、変更します。

![image](https://github.com/user-attachments/assets/4e189f95-4123-41f1-b299-8071238e37f2)
