### PR TITLE
RubyとRailsの対応バージョンを変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0']
+        ruby: ['3.2']
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0']
-        rails: ['6_1', '7_0', '7_1']
+        ruby: ['3.2']
+        rails: ['7_0', '7_1']
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-eval_gemfile File.expand_path('../Gemfile', __dir__)
-
-dependencies.delete_if { |d| d.name == 'rails' }
-gem 'rails', '~> 6.1.0'

--- a/vision.gemspec
+++ b/vision.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", '>= 6.0.0', '< 7.2'
   spec.add_dependency "haml-rails", "~> 2.0"
+  spec.add_dependency "concurrent-ruby", "1.3.4" # Rails7.0でのエラー対策
 
   spec.test_files = Dir["spec/**/*"]
 end

--- a/vision.gemspec
+++ b/vision.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", '>= 6.0.0', '< 7.3'
+  spec.add_dependency "rails", '>= 6.0.0', '< 7.2'
   spec.add_dependency "haml-rails", "~> 2.0"
 
   spec.test_files = Dir["spec/**/*"]


### PR DESCRIPTION
- Rubyは3.0から3.2へ変更
- Railsは6.0を削除、7.2を追加